### PR TITLE
Add feature to fork only the default branch

### DIFF
--- a/src/main/java/org/kohsuke/github/GHMeta.java
+++ b/src/main/java/org/kohsuke/github/GHMeta.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 // TODO: Auto-generated Javadoc
 /**
@@ -12,7 +13,8 @@ import java.util.List;
  *
  * @author Paulo Miguel Almeida
  * @see GitHub#getMeta() GitHub#getMeta()
- * @see <a href="https://developer.github.com/v3/meta/#meta">Get Meta</a>
+ * @see <a href="https://docs.github.com/en/rest/meta/meta?apiVersion=2022-11-28#get-github-meta-information">Get
+ *      Meta</a>
  */
 public class GHMeta {
 
@@ -24,6 +26,10 @@ public class GHMeta {
 
     @JsonProperty("verifiable_password_authentication")
     private boolean verifiablePasswordAuthentication;
+    @JsonProperty("ssh_key_fingerprints")
+    private Map<String, String> sshKeyFingerprints;
+    @JsonProperty("ssh_keys")
+    private List<String> sshKeys;
     private List<String> hooks;
     private List<String> git;
     private List<String> web;
@@ -41,6 +47,24 @@ public class GHMeta {
      */
     public boolean isVerifiablePasswordAuthentication() {
         return verifiablePasswordAuthentication;
+    }
+
+    /**
+     * Gets ssh key fingerprints.
+     *
+     * @return the ssh key fingerprints
+     */
+    public Map<String, String> getSshKeyFingerprints() {
+        return Collections.unmodifiableMap(sshKeyFingerprints);
+    }
+
+    /**
+     * Gets ssh keys.
+     *
+     * @return the ssh keys
+     */
+    public List<String> getSshKeys() {
+        return Collections.unmodifiableList(sshKeys);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1539,7 +1539,7 @@ public class GHRepository extends GHObject {
             name = name != null ? name : this.name;
             GHRepository r;
             try {
-                r =  GHRepository.read(root(), login, name);
+                r =  GHRepository.read(root(), root().getMyself().getLogin(), name);
             } catch (FileNotFoundException e) {
                 r = null;
             }
@@ -1553,6 +1553,27 @@ public class GHRepository extends GHObject {
             }
         }
         throw new IOException(this + " was forked but can't find the new repository");
+    }
+
+    /**
+     * Creates a fork of this repository.
+     *
+     * @param defaultBranchOnly if true, only the default branch will be forked
+     * @return the newly forked repository
+     * @throws IOException if an I/O error occurs
+     */
+    public GHRepository createFork(boolean defaultBranchOnly) throws IOException {
+        return createFork(null, null, defaultBranchOnly);
+    }
+
+    /**
+     * Creates a fork of this repository with the default branch only.
+     *
+     * @return the newly forked repository
+     * @throws IOException if an I/O error occurs
+     */
+    public GHRepository createFork() throws IOException {
+        return createFork(true);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1501,13 +1501,18 @@ public class GHRepository extends GHObject {
     /**
      * Creates a fork of this repository with optional parameters.
      *
-     * @param organization      the organization to fork to, or null to fork to the authenticated user's account
-     * @param name              the name of the new repository, or null to use the same name as the original repository
-     * @param defaultBranchOnly whether to fork only the default branch
+     * @param organization
+     *            the organization to fork to, or null to fork to the authenticated user's account
+     * @param name
+     *            the name of the new repository, or null to use the same name as the original repository
+     * @param defaultBranchOnly
+     *            whether to fork only the default branch
      * @return the newly forked repository
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
-    public GHRepository createFork(@Nullable String organization, @Nullable String name, boolean defaultBranchOnly) throws IOException {
+    public GHRepository createFork(@Nullable String organization, @Nullable String name, boolean defaultBranchOnly)
+            throws IOException {
 
         if (organization != null && organization.isEmpty()) {
             throw new IllegalArgumentException("Organization cannot be empty");

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1501,24 +1501,23 @@ public class GHRepository extends GHObject {
     /**
      * Creates a fork of this repository with optional parameters.
      *
-     * @param organization
-     *            the organization to fork to, or null to fork to the authenticated user's account
-     * @param name
-     *            the name of the new repository, or null to use the same name as the original repository
-     * @param defaultBranchOnly
-     *            whether to fork only the default branch
+     * @param organization      the organization to fork to, or null to fork to the authenticated user's account
+     * @param name              the name of the new repository, or null to use the same name as the original repository
+     * @param defaultBranchOnly whether to fork only the default branch
      * @return the newly forked repository
-     * @throws IOException
-     *             if an I/O error occurs
+     * @throws IOException if an I/O error occurs
      */
-    public GHRepository createFork(String organization, String name, boolean defaultBranchOnly) throws IOException {
+    public GHRepository createFork(@Nullable String organization, @Nullable String name, boolean defaultBranchOnly) throws IOException {
+
         if (organization != null && organization.isEmpty()) {
             throw new IllegalArgumentException("Organization cannot be empty");
         }
         if (name != null && name.isEmpty()) {
             throw new IllegalArgumentException("Name cannot be empty");
         }
-
+        if (name != null && !name.matches("^[a-zA-Z0-9._-]+$")) {
+            throw new IllegalArgumentException("Repository name contains invalid characters");
+        }
         Requester requester = root().createRequest().method("POST").withUrlPath(getApiTailUrl("forks"));
 
         if (organization != null) {

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1455,7 +1455,7 @@ public class GHRepository extends GHObject {
     /**
      * Forks this repository as your repository.
      *
-     * @return Newly forked repository that belong to you.
+     * @return Newly forked repository that belongs to you.
      * @throws IOException
      *             the io exception
      * @deprecated Use {@link #createFork(String, String, boolean)} instead
@@ -1488,7 +1488,7 @@ public class GHRepository extends GHObject {
      *
      * @param org
      *            the org
-     * @return Newly forked repository that belong to you.
+     * @return Newly forked repository that belongs to you.
      * @throws IOException
      *             the io exception
      * @deprecated Use {@link #createFork(String, String, boolean)} instead

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1539,7 +1539,7 @@ public class GHRepository extends GHObject {
             name = name != null ? name : this.name;
             GHRepository r;
             try {
-                r =  GHRepository.read(root(), root().getMyself().getLogin(), name);
+                r = GHRepository.read(root(), root().getMyself().getLogin(), name);
             } catch (FileNotFoundException e) {
                 r = null;
             }
@@ -1558,9 +1558,11 @@ public class GHRepository extends GHObject {
     /**
      * Creates a fork of this repository.
      *
-     * @param defaultBranchOnly if true, only the default branch will be forked
+     * @param defaultBranchOnly
+     *            if true, only the default branch will be forked
      * @return the newly forked repository
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
     public GHRepository createFork(boolean defaultBranchOnly) throws IOException {
         return createFork(null, null, defaultBranchOnly);
@@ -1570,7 +1572,8 @@ public class GHRepository extends GHObject {
      * Creates a fork of this repository with the default branch only.
      *
      * @return the newly forked repository
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
     public GHRepository createFork() throws IOException {
         return createFork(true);

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1458,9 +1458,9 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
-     * @deprecated
+     * @deprecated Use {@link #createFork(String, String, boolean)} instead
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public GHRepository fork() throws IOException {
         return createFork(null, null, false);
     }
@@ -1491,9 +1491,9 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
-     * @deprecated
+     * @deprecated Use {@link #createFork(String, String, boolean)} instead
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public GHRepository forkTo(GHOrganization org) throws IOException {
         return createFork(org.getLogin(), null, false);
     }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1458,7 +1458,7 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
-     *  @deprecated
+     * @deprecated
      */
     @Deprecated
     public GHRepository fork() throws IOException {
@@ -1491,7 +1491,7 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
-     *  @deprecated
+     * @deprecated
      */
     @Deprecated
     public GHRepository forkTo(GHOrganization org) throws IOException {
@@ -1535,7 +1535,8 @@ public class GHRepository extends GHObject {
 
         // this API is asynchronous. we need to wait for a bit
         for (int i = 0; i < 10; i++) {
-            GHRepository r = organization != null ? root().getOrganization(organization).getRepository(name != null ? name : this.name)
+            GHRepository r = organization != null
+                    ? root().getOrganization(organization).getRepository(name != null ? name : this.name)
                     : root().getMyself().getRepository(name != null ? name : this.name);
             if (r != null) {
                 return r;

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1458,6 +1458,7 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
+     *  @deprecated
      */
     @Deprecated
     public GHRepository fork() throws IOException {
@@ -1490,6 +1491,7 @@ public class GHRepository extends GHObject {
      * @return Newly forked repository that belong to you.
      * @throws IOException
      *             the io exception
+     *  @deprecated
      */
     @Deprecated
     public GHRepository forkTo(GHOrganization org) throws IOException {

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -834,7 +834,8 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         String repositoryName = "rubywm";
         String upstreamRepositoryOrganization = "kohsuke";
         cleanupRepository(GITHUB_API_TEST_ORG + "/" + repositoryName);
-        GHRepository forkedRepository = gitHub.getRepository(upstreamRepositoryOrganization + "/" + repositoryName).createFork(gitHub.getOrganization(GITHUB_API_TEST_ORG).name, repositoryName, true);
+        GHRepository forkedRepository = gitHub.getRepository(upstreamRepositoryOrganization + "/" + repositoryName)
+                .createFork(gitHub.getOrganization(GITHUB_API_TEST_ORG).name, repositoryName, true);
         assertThat(forkedRepository, notNullValue());
         assertThat(forkedRepository.getOwnerName(), equalTo("new-owner"));
         assertThat(forkedRepository.getName(), equalTo("new-repo"));

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -831,8 +831,10 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
      */
     @Test
     public void testCreateForkWithValidParameters() throws IOException {
-        GHRepository repository = getRepository();
-        GHRepository forkedRepository = repository.createFork("new-owner", "new-repo", true);
+        String repositoryName = "rubywm";
+        String upstreamRepositoryOrganization = "kohsuke";
+        cleanupRepository(GITHUB_API_TEST_ORG + "/" + repositoryName);
+        GHRepository forkedRepository = gitHub.getRepository(upstreamRepositoryOrganization + "/" + repositoryName).createFork(gitHub.getOrganization(GITHUB_API_TEST_ORG).name, repositoryName, true);
         assertThat(forkedRepository, notNullValue());
         assertThat(forkedRepository.getOwnerName(), equalTo("new-owner"));
         assertThat(forkedRepository.getName(), equalTo("new-repo"));

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -824,6 +824,33 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     }
 
     /**
+     * Test createFork method with valid parameters.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Test
+    public void testCreateForkWithValidParameters() throws IOException {
+        GHRepository repository = getRepository();
+        GHRepository forkedRepository = repository.createFork("new-owner", "new-repo", true);
+        assertThat(forkedRepository, notNullValue());
+        assertThat(forkedRepository.getOwnerName(), equalTo("new-owner"));
+        assertThat(forkedRepository.getName(), equalTo("new-repo"));
+    }
+
+    /**
+     * Test createFork method with invalid parameters.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateForkWithInvalidParameters() throws IOException {
+        GHRepository repository = getRepository();
+        repository.createFork(null, "", true);
+    }
+
+    /**
      * List commit comments some comments.
      *
      * @throws IOException

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -283,6 +283,8 @@ public class GitHubTest extends AbstractGitHubWireMockTest {
     public void getMeta() throws IOException {
         GHMeta meta = gitHub.getMeta();
         assertThat(meta.isVerifiablePasswordAuthentication(), is(true));
+        assertThat(meta.getSshKeyFingerprints().size(), equalTo(4));
+        assertThat(meta.getSshKeys().size(), equalTo(3));
         assertThat(meta.getApi().size(), equalTo(19));
         assertThat(meta.getGit().size(), equalTo(36));
         assertThat(meta.getHooks().size(), equalTo(4));

--- a/src/test/java/org/kohsuke/github/GitHubWireMockRule.java
+++ b/src/test/java/org/kohsuke/github/GitHubWireMockRule.java
@@ -241,6 +241,16 @@ public class GitHubWireMockRule extends WireMockMultiServerRule {
                     .stubFor(any(anyUrl()).willReturn(aResponse().withTransformers(ProxyToOriginalHostTransformer.NAME))
                             .atPriority(100));
         }
+
+        this.apiServer()
+                .stubFor(post(urlMatching("/repos/.*/forks")).willReturn(aResponse().withStatus(202)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("fork.json")));
+
+        this.apiServer()
+                .stubFor(get(urlMatching("/repos/hub4j-test-org/github-api")).willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("repository.json")));
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GitHubWireMockRule.java
+++ b/src/test/java/org/kohsuke/github/GitHubWireMockRule.java
@@ -241,16 +241,6 @@ public class GitHubWireMockRule extends WireMockMultiServerRule {
                     .stubFor(any(anyUrl()).willReturn(aResponse().withTransformers(ProxyToOriginalHostTransformer.NAME))
                             .atPriority(100));
         }
-
-        this.apiServer()
-                .stubFor(post(urlMatching("/repos/.*/forks")).willReturn(aResponse().withStatus(202)
-                        .withHeader("Content-Type", "application/json")
-                        .withBodyFile("fork.json")));
-
-        this.apiServer()
-                .stubFor(get(urlMatching("/repos/hub4j-test-org/github-api")).willReturn(aResponse().withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBodyFile("repository.json")));
     }
 
     /**

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/__files/1-meta.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/__files/1-meta.json
@@ -1,5 +1,16 @@
 {
   "verifiable_password_authentication": true,
+  "ssh_key_fingerprints": {
+    "SHA256_RSA": 1234567890,
+    "SHA256_DSA": 1234567890,
+    "SHA256_ECDSA": 1234567890,
+    "SHA256_ED25519": 1234567890
+  },
+  "ssh_keys": [
+    "ssh-ed25519 ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "ecdsa-sha2-nistp256 ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "ssh-rsa ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  ],
   "hooks": [
     "192.30.252.0/22",
     "185.199.108.0/22",


### PR DESCRIPTION
Fixes #1

Add functionality to fork only the default branch of a repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for creating forks with enhanced flexibility, allowing specification of organization, repository name, and default branch options.
	- Added access to SSH key information in the metadata retrieval.
- **Bug Fixes**
	- Improved error handling for invalid parameters in the fork creation process.
- **Tests**
	- Added test cases to validate the new fork creation functionality, including checks for valid and invalid parameters.
	- Enhanced assertions in existing tests to verify SSH key metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->